### PR TITLE
Use epsg 3035 for NUTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ A modular `snakemake` workflow built for [`clio`](https://clio.readthedocs.io/) 
 ## Steps
 
 1. Data is downloaded and harmonized using a common schema (see `workflow/scripts/_schema.py`).
-    - Country area data: for now, only [GADM](https://gadm.org/) and [Overture Maps](https://overturemaps.org/) divisions are supported as datasources.
+    - Country area data: [GADM](https://gadm.org/), [Overture Maps](https://overturemaps.org/) and [NUTS](https://ec.europa.eu/eurostat/web/gisco/geodata/statistical-units/territorial-units-statistics) divisions are supported as datasources.
     - [Marine regions](https://www.marineregions.org/) Exclusive Economic Zone (EEZ) data.
-2. Country area is clipped using the marine regions to approximate their landmass.
+2. Country area is clipped using the marine regions to accurately approximate their landmass.
 3. The marine data and the clipped land mass data are combined following the schema.
 Contested EEZ's (e.g., Taiwan, Falkland islands) are removed during this step.
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,17 +1,19 @@
 # A minimal example of how to configure this module
-buffer: 500  # EPSG:3857 is in meters
+buffer: 50  # EPSG:3857 is in meters
 crs:
   projected: "epsg:3857"
   geographic: "epsg:4326"
 countries:
   DNK:
     subtype: "1"
-    source: "gadm"
+    source: "nuts"
+    resolution: 01M
+    year: 2024
   GBR:
     subtype: "country"
     source: "overture"
   NLD:
-    subtype: "2"
+    subtype: "0"
     source: "gadm"
   BEL:
     subtype: "country"
@@ -22,5 +24,5 @@ countries:
   ESP:
     subtype: "2"
     source: "nuts"
-    resolution: 20M
-    year: 2003
+    resolution: 01M
+    year: 2024

--- a/workflow/internal/settings.yaml
+++ b/workflow/internal/settings.yaml
@@ -5,4 +5,4 @@ resources:
     dummy_readme: "https://raw.githubusercontent.com/calliope-project/clio/refs/heads/main/README.md"
   overture_release: "2025-01-22.0"
 nuts:
-  epsg: 4326  # will be converted later to the user-requested epsg
+  epsg: 3035  # will be converted later to the user-requested epsg

--- a/workflow/scripts/download_nuts.py
+++ b/workflow/scripts/download_nuts.py
@@ -16,6 +16,7 @@ def download_nuts_version(year: int, resolution: str, level: str, epsg: str, pat
     gdf = gpd.read_file(
         URL.format(year=year, resolution=resolution, epsg=epsg, level=level)
     )
+    assert gdf.crs.equals(epsg)
     gdf.to_parquet(path)
 
 


### PR DESCRIPTION
Fixes #6, #5

## Summary of changes in this pull request

* Use files in epsg 3035 during the NUTS download. Other GISCO files seem to be distorted!
* Update README to mention NUTS

## Reviewer checklist

* [x] `INTERFACE.yaml` is up-to-date with all relevant user resources and results.
* [x] The integration example is up-to-date with a minimal use-case of the module.
* [x] Module documentation is up-to-date.
