### PR TITLE
Pycountry -> country_convertor

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1,8 +1,20 @@
 version: 7
 platforms:
 - name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
 - name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
 - name: win-64
+  virtual-packages:
+  - __win=10.0
+  - __archspec=0=x86_64
 environments:
   default:
     channels:
@@ -943,6 +955,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/country_converter-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.2.0-h6c4a22f_0.conda
@@ -988,7 +1001,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -1045,6 +1057,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/country_converter-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.2.0-h6c4a22f_0.conda
@@ -1090,7 +1103,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ptyprocess-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -1291,6 +1303,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/country_converter-1.3.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhcf101f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/decorator-5.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/duckdb-1.2.0-h6c4a22f_0.conda
@@ -1334,7 +1347,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.10.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.13.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
@@ -6436,6 +6448,17 @@ packages:
   license_family: MIT
   size: 8331
   timestamp: 1608581999360
+- conda: https://conda.anaconda.org/conda-forge/noarch/country_converter-1.3.2-pyhd8ed1ab_0.conda
+  sha256: b161a074b92715b9b6a53c35bb84abc0cecea4299ca76b0aaebab0e35b46f3dc
+  md5: 193a9e54636d8d70781a3e56370f5502
+  depends:
+  - pandas >=1.0.0
+  - python >=3.9
+  license: GPL-3.0-or-later
+  license_family: GPL
+  run_exports: {}
+  size: 51091
+  timestamp: 1761151175246
 - conda: https://conda.anaconda.org/conda-forge/noarch/cpython-3.12.12-py312hd8ed1ab_1.conda
   noarch: generic
   sha256: b88c76a6d6b45378552ccfd9e88b2a073161fe83fd1294c8fa103ffd32f7934a
@@ -7528,17 +7551,6 @@ packages:
   license_family: BSD
   size: 14671
   timestamp: 1752769938071
-- conda: https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda
-  sha256: de60a268ee916eab46016e8b76b6bbd858710dcedeb7188d5e100b863c24cd1c
-  md5: 62ed8c560f1b5b8d74ed11e68e9ae223
-  depends:
-  - python >=3.6,<4.0
-  - setuptools
-  license: LGPL-2.1-or-later
-  license_family: LGPL
-  run_exports: {}
-  size: 3105570
-  timestamp: 1718094617616
 - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
   sha256: 79db7928d13fab2d892592223d7570f5061c192f27b9febd1a418427b719acc6
   md5: 12c566707c80111f9799308d9e265aef

--- a/pixi.toml
+++ b/pixi.toml
@@ -30,7 +30,6 @@ ipdb = ">=0.13.13"
 pandera-geopandas = ">=0.24"
 pandera-io = ">=0.24"
 pyarrow = ">=19.0.1"
-pycountry = ">=24.6.1"
 shapely = ">=2.1.1"
 numpy = ">=2.3.5"
 pandas = ">=3.0.2"
@@ -38,6 +37,7 @@ pytz = ">=2026.2"
 requests = ">=2.33.1"
 antimeridian = ">=0.4.7"
 rasterio = ">=1.4.4"
+country_converter = ">=1.3.2"
 
 [environments]
 module = { features = ["module"], no-default-feature = true }

--- a/workflow/envs/module.linux-64.pin.txt
+++ b/workflow/envs/module.linux-64.pin.txt
@@ -84,7 +84,6 @@ https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda#c6
 https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda#8c4061f499edec6b8ac7000f6d586829
 https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.4-py312h762fea3_0.conda#df884dc5a76b2e2b2d13901f0d5d1668
 https://conda.anaconda.org/conda-forge/noarch/pytz-2026.2-pyhcf101f3_0.conda#03cb60f505ad3ada0a95277af5faeb1a
-https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda#62ed8c560f1b5b8d74ed11e68e9ae223
 https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260107.1-cxx17_h7b12aa8_0.conda#6f7b4302263347698fd24565fbf11310
 https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda#ced7f10b6cfb4389385556f47c0ad949
 https://conda.anaconda.org/conda-forge/linux-64/re2-2025.11.05-h5301d42_1.conda#66a715bc01c77d43aca1f9fcb13dde3c
@@ -249,6 +248,7 @@ https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda#
 https://conda.anaconda.org/conda-forge/noarch/ipdb-0.13.13-pyhd8ed1ab_1.conda#044c5249ad8ea18a414d07baa1f369ea
 https://conda.anaconda.org/conda-forge/linux-64/python-duckdb-1.2.0-py312h2ec8cdc_0.conda#53f480e05bc0cd78046a13965650665d
 https://conda.anaconda.org/conda-forge/noarch/duckdb-1.2.0-h6c4a22f_0.conda#106a9ca2e65f476ff2499ba74c9e1db0
+https://conda.anaconda.org/conda-forge/noarch/country_converter-1.3.2-pyhd8ed1ab_0.conda#193a9e54636d8d70781a3e56370f5502
 https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda#cc73a9bd315659dc5307a5270f44786f
 https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.76-pyhd8ed1ab_0.conda#4babebd5361bc44503358a519a81a465
 https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.14.0-pyhd8ed1ab_0.conda#4e3089ce93822a25408c480dd53561b6

--- a/workflow/envs/module.osx-arm64.pin.txt
+++ b/workflow/envs/module.osx-arm64.pin.txt
@@ -78,7 +78,6 @@ https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda#c6
 https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda#8c4061f499edec6b8ac7000f6d586829
 https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.4.4-py313hb3bd904_0.conda#699df60947da770aa55348cccfa4f082
 https://conda.anaconda.org/conda-forge/noarch/pytz-2026.2-pyhcf101f3_0.conda#03cb60f505ad3ada0a95277af5faeb1a
-https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda#62ed8c560f1b5b8d74ed11e68e9ae223
 https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260107.1-cxx17_h2062a1b_0.conda#bb65152e0d7c7178c0f1ee25692c9fd1
 https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda#40d8ad21be4ccfff83a314076c3563f4
 https://conda.anaconda.org/conda-forge/osx-arm64/re2-2025.11.05-ha480c28_1.conda#a1ff22f664b0affa3de712749ccfbf04
@@ -241,6 +240,7 @@ https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyh53cf698_0.conda#
 https://conda.anaconda.org/conda-forge/noarch/ipdb-0.13.13-pyhd8ed1ab_1.conda#044c5249ad8ea18a414d07baa1f369ea
 https://conda.anaconda.org/conda-forge/osx-arm64/python-duckdb-1.2.0-py313h928ef07_0.conda#658db108cac1cdf2419dfe59c0a58de7
 https://conda.anaconda.org/conda-forge/noarch/duckdb-1.2.0-h6c4a22f_0.conda#106a9ca2e65f476ff2499ba74c9e1db0
+https://conda.anaconda.org/conda-forge/noarch/country_converter-1.3.2-pyhd8ed1ab_0.conda#193a9e54636d8d70781a3e56370f5502
 https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda#cc73a9bd315659dc5307a5270f44786f
 https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.76-pyhd8ed1ab_0.conda#4babebd5361bc44503358a519a81a465
 https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.14.0-pyhd8ed1ab_0.conda#4e3089ce93822a25408c480dd53561b6

--- a/workflow/envs/module.win-64.pin.txt
+++ b/workflow/envs/module.win-64.pin.txt
@@ -73,7 +73,6 @@ https://conda.anaconda.org/conda-forge/noarch/attrs-26.1.0-pyhcf101f3_0.conda#c6
 https://conda.anaconda.org/conda-forge/noarch/affine-2.4.0-pyhd8ed1ab_1.conda#8c4061f499edec6b8ac7000f6d586829
 https://conda.anaconda.org/conda-forge/win-64/rasterio-1.4.4-py313ha5c5119_0.conda#c094475643548d60959967b5be3638bb
 https://conda.anaconda.org/conda-forge/noarch/pytz-2026.2-pyhcf101f3_0.conda#03cb60f505ad3ada0a95277af5faeb1a
-https://conda.anaconda.org/conda-forge/noarch/pycountry-24.6.1-pyhd8ed1ab_0.conda#62ed8c560f1b5b8d74ed11e68e9ae223
 https://conda.anaconda.org/conda-forge/win-64/libabseil-20260107.1-cxx17_h0eb2380_0.conda#60da39dd5fd93b2a4a0f986f3acc2520
 https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.11.05-h04e5de1_1.conda#3d863f1a19f579ca511f6ac02038ab5a
 https://conda.anaconda.org/conda-forge/win-64/re2-2025.11.05-ha104f34_1.conda#6807f05dcf3f1736ad6cc9525b8b8725
@@ -229,6 +228,7 @@ https://conda.anaconda.org/conda-forge/noarch/ipython-9.14.1-pyhe2676ad_0.conda#
 https://conda.anaconda.org/conda-forge/noarch/ipdb-0.13.13-pyhd8ed1ab_1.conda#044c5249ad8ea18a414d07baa1f369ea
 https://conda.anaconda.org/conda-forge/win-64/python-duckdb-1.2.0-py313h5813708_0.conda#b3c2cbd55b1c0a3dd723d08bbdebba06
 https://conda.anaconda.org/conda-forge/noarch/duckdb-1.2.0-h6c4a22f_0.conda#106a9ca2e65f476ff2499ba74c9e1db0
+https://conda.anaconda.org/conda-forge/noarch/country_converter-1.3.2-pyhd8ed1ab_0.conda#193a9e54636d8d70781a3e56370f5502
 https://conda.anaconda.org/conda-forge/noarch/jmespath-1.1.0-pyhcf101f3_1.conda#cc73a9bd315659dc5307a5270f44786f
 https://conda.anaconda.org/conda-forge/noarch/botocore-1.40.76-pyhd8ed1ab_0.conda#4babebd5361bc44503358a519a81a465
 https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.14.0-pyhd8ed1ab_0.conda#4e3089ce93822a25408c480dd53561b6

--- a/workflow/envs/module.yaml
+++ b/workflow/envs/module.yaml
@@ -11,7 +11,6 @@ dependencies:
 - pandera-geopandas >=0.24
 - pandera-io >=0.24
 - pyarrow >=19.0.1
-- pycountry >=24.6.1
 - shapely >=2.1.1
 - numpy >=2.3.5
 - pandas >=3.0.2
@@ -19,3 +18,4 @@ dependencies:
 - requests >=2.33.1
 - antimeridian >=0.4.7
 - rasterio >=1.4.4
+- country_converter >=1.3.2

--- a/workflow/scripts/download_harmonised_overture.py
+++ b/workflow/scripts/download_harmonised_overture.py
@@ -6,9 +6,9 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import boto3
+import country_converter as coco
 import duckdb
 import geopandas as gpd
-import pycountry
 from _schemas import ShapesSchema
 from botocore import UNSIGNED
 from botocore.config import Config
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     snakemake: Any
 
 
+CC = coco.CountryConverter()
 S3_REGION = "us-west-2"
 S3_BUCKET = f"overturemaps-{S3_REGION}"
 S3_RELEASE_PREFIX = "release/"
@@ -92,7 +93,7 @@ def download_country_overture(country: str, subtype: str, version: str, path: st
     Uses duckdb for remote interfacing and 'larger than memory' file generation.
     """
     # Prepare variables for the request
-    country_a2 = pycountry.countries.get(alpha_3=country).alpha_2
+    country_a2 = CC.convert(country, src="ISO3", to="ISO2")
     overture_glob = _resolve_overture_glob(version)
 
     # Setup SQL connection to the remote dataset

--- a/workflow/scripts/harmonise_nuts.py
+++ b/workflow/scripts/harmonise_nuts.py
@@ -4,13 +4,14 @@ import sys
 from typing import TYPE_CHECKING, Any
 
 import _schemas
+import country_converter as coco
 import geopandas as gpd
-import pycountry
 
 if TYPE_CHECKING:
     snakemake: Any
 sys.stderr = open(snakemake.log[0], "w")
 
+CC = coco.CountryConverter()
 UNIQUE_ISO3_TO_NUTS = {
     "GRC": "EL",  # Greece
     "GBR": "UK",  # United Kingdom
@@ -21,7 +22,7 @@ def _iso_a3_to_nuts(code):
     """Obtain NUTS code for the requested country, handling special cases."""
     nuts = UNIQUE_ISO3_TO_NUTS.get(code, None)
     if nuts is None:
-        nuts = pycountry.countries.get(alpha_3=code).alpha_2
+        nuts = CC.convert(code, src="ISO3", to="ISO2")
     return nuts
 
 


### PR DESCRIPTION
Fixes #58 

## Reviewer checklist

* [x] There are no `pip` dependencies in the module's environment files (`workflow/envs/`).
* [x] All rules use `pathvars` (e.g., `<results>`) in their inputs and outputs.
* [x] The integration test-suite is successful, including:
    * [x] `pre-commit.ci` tests pass.
    * [x] tests pass for all relevant OS configurations (linux, osx, windows).
* [x] Module documentation is up-to-date, including:
    * [x] `INTERFACE.yaml` mentions all relevant `pathvars` and `wildcards`.
    * [x] `README.md` describes how to use the module and has the necessary citations.
