### PR TITLE
Add release control for all data sources

### DIFF
--- a/workflow/internal/config.schema.yaml
+++ b/workflow/internal/config.schema.yaml
@@ -237,20 +237,33 @@ properties:
     $ref: "#/$defs/partialVoronoiEEZSettings"
   gdal:
     $ref: "#/$defs/gdalSettings"
-  overture_release:
-    description: |
-      Overture data release to use. Two options are possible:
-      - A specific release string in the form of 'yyyy-mm-dd.x'.
-      - A request for the latest release in the form of 'latest'.
-    type: string
-    default: "latest"
-    pattern: "^(?:latest|(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])\\.\\d+)$"
-  marine_regions_release:
-    description: |
-      MarineRegions WFS version to use to access EEZ data.
-    type: string
-    default: "2.0.0"
-    pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+  releases:
+    type: object
+    additionalProperties: false
+    properties:
+      overture:
+        description: |
+          Overture data release to use. Two options are possible:
+          - A request for the latest release in the form of 'latest' (recommended).
+          - A specific release string in the form of 'yyyy-mm-dd.x'.
+        type: string
+        default: "latest"
+        pattern: "^(?:latest|(?:\\d{4})-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\\d|3[01])\\.\\d+)$"
+      marine_regions:
+        description: MarineRegions WFS release to use to access EEZ data.
+        type: string
+        default: "2.0.0"
+        pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
+      gadm:
+        description: "GADM release to use."
+        type: string
+        default: "4.1"
+        enum: ["4.1"]  # GADM does not follow semver
+      geoboundaries:
+        description: "geoBoundaries release to use."
+        type: string
+        default: "6.0.0"
+        pattern: "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"
   scenarios:
     description: >
       Shape-building scenarios to run.

--- a/workflow/internal/settings.yaml
+++ b/workflow/internal/settings.yaml
@@ -14,5 +14,8 @@ timeouts:
   initial_retry_seconds: 5
 gdal:
   geojson_max_obj_size_mb: 1024
-overture_release: "latest"
-marine_regions_release: "2.0.0"
+releases:
+  overture: latest
+  marine_regions: "2.0.0"
+  gadm: "4.1"
+  geoboundaries: "6.0.0"

--- a/workflow/rules/_utils.smk
+++ b/workflow/rules/_utils.smk
@@ -61,7 +61,7 @@ def get_eez_file(scenario: str, country: str) -> str:
     if extra_eez:
         file_path = f"combined/{country}_{'_'.join([str(i) for i in extra_eez])}"
     else:
-        file_path = f"single/{country}"
+        file_path = f"single/{get_release('marine_regions')}/{country}"
     return file_path
 
 

--- a/workflow/rules/_utils.smk
+++ b/workflow/rules/_utils.smk
@@ -1,6 +1,12 @@
 """Utility functions for snakemake rule handling."""
 
 
+def get_release(source: str):
+    """Obtain (pre)configured release to use for a source dataset."""
+    releases = internal["releases"] | config.get("releases", {})
+    return releases[source]
+
+
 def get_country_file(scenario: str, country: str):
     """Build unique file names to avoid overwriting source files.
 
@@ -11,14 +17,18 @@ def get_country_file(scenario: str, country: str):
     source = country_settings["source"]
     subtype = country_settings["subtype"]
 
-    filename = f"{source}/harmonise/{country}_{subtype}"
+    if source == "nuts":
+        release = country_settings["year"]
+    else:
+        release = get_release(source)
+
+    filename = f"{source}/harmonise/{release}/{country}_{subtype}"
     if source == "nuts":
         resolution = country_settings["resolution"]
-        year = country_settings["year"]
-        filename += f"_{year}_{resolution}"
+        filename += f"_{resolution}"
     elif source == "geoboundaries":
-        release = country_settings["release_type"]
-        filename += f"_{release}"
+        release_type = country_settings["release_type"]
+        filename += f"_{release_type}"
 
     return filename
 

--- a/workflow/rules/build.smk
+++ b/workflow/rules/build.smk
@@ -3,9 +3,9 @@
 
 rule build_eez:
     input:
-        country="<resources>/automatic/eez/single/{country}.parquet",
+        country=f"<resources>/automatic/eez/single/{get_release('marine_regions')}/{{country}}.parquet",
         extra=lambda wc: [
-            f"<resources>/automatic/eez/single/{mrgid}.parquet"
+            f"<resources>/automatic/eez/single/{get_release('marine_regions')}/{mrgid}.parquet"
             for mrgid in get_extra_eez_from_key(wc.eez_key)
         ],
     output:

--- a/workflow/rules/download.smk
+++ b/workflow/rules/download.smk
@@ -18,9 +18,9 @@ rule download_duckdb_extensions:
 
 rule download_geoboundaries:
     output:
-        path="<resources>/automatic/geoboundaries/download/{country}_{subtype}_{release_type}.parquet",
+        path="<resources>/automatic/geoboundaries/download/{release}/{country}_{subtype}_{release_type}.parquet",
     log:
-        "<logs>/geoboundaries/download/{country}_{subtype}_{release_type}.log",
+        "<logs>/geoboundaries/download/{release}/{country}_{subtype}_{release_type}.log",
     localrule: True
     conda:
         "../envs/module.yaml"
@@ -28,16 +28,16 @@ rule download_geoboundaries:
         timeouts=internal["timeouts"],
         geojson_max_obj_size_mb=get_gdal_config()["geojson_max_obj_size_mb"],
     message:
-        "Downloading '{wildcards.country}_{wildcards.subtype}_{wildcards.release_type}' dataset from geoBoundaries."
+        "Downloading geoBoundaries {wildcards.release}: {wildcards.country}_{wildcards.subtype}_{wildcards.release_type}."
     script:
         "../scripts/download_geoboundaries.py"
 
 
 rule download_gadm:
     output:
-        path="<resources>/automatic/gadm/download/{country}_{subtype}.parquet",
+        path="<resources>/automatic/gadm/download/{release}/{country}_{subtype}.parquet",
     log:
-        "<logs>/gadm/download/{country}_{subtype}.log",
+        "<logs>/gadm/download/{release}/{country}_{subtype}.log",
     localrule: True
     conda:
         "../envs/module.yaml"
@@ -45,22 +45,22 @@ rule download_gadm:
         timeouts=internal["timeouts"],
         geojson_max_obj_size_mb=get_gdal_config()["geojson_max_obj_size_mb"],
     message:
-        "Download '{wildcards.country}_{wildcards.subtype}' dataset from GADM."
+        "Downloading GADM {wildcards.release}: {wildcards.country}_{wildcards.subtype}."
     script:
         "../scripts/download_gadm.py"
 
 
 rule download_nuts:
     output:
-        path="<resources>/automatic/nuts/download/{subtype}_{resolution}_{year}.parquet",
+        path="<resources>/automatic/nuts/download/{release}/{subtype}_{resolution}.parquet",
     log:
-        "<logs>/nuts/download/{subtype}_{resolution}_{year}.log",
+        "<logs>/nuts/download/{release}/{subtype}_{resolution}.log",
     localrule: True
     conda:
         "../envs/module.yaml"
     params:
         timeouts=internal["timeouts"],
     message:
-        "Download '{wildcards.subtype}_{wildcards.resolution}_{wildcards.year}' from NUTS."
+        "Downloading NUTS {wildcards.release}: {wildcards.subtype}_{wildcards.resolution}."
     script:
         "../scripts/download_nuts.py"

--- a/workflow/rules/harmonise.smk
+++ b/workflow/rules/harmonise.smk
@@ -5,13 +5,13 @@ rule harmonise_geoboundaries:
     input:
         raw=rules.download_geoboundaries.output.path,
     output:
-        path="<resources>/automatic/geoboundaries/harmonise/{country}_{subtype}_{release_type}.parquet",
+        path="<resources>/automatic/geoboundaries/harmonise/{release}/{country}_{subtype}_{release_type}.parquet",
     log:
-        "<logs>/geoboundaries/harmonise/{country}_{subtype}_{release_type}.log",
+        "<logs>/geoboundaries/harmonise/{release}/{country}_{subtype}_{release_type}.log",
     conda:
         "../envs/module.yaml"
     message:
-        "Harmonising '{wildcards.country}_{wildcards.subtype}_{wildcards.release_type}' dataset from geoBoundaries."
+        "Harmonising geoBoundaries {wildcards.release}: {wildcards.country}_{wildcards.subtype}_{wildcards.release_type}."
     script:
         "../scripts/harmonise_geoboundaries.py"
 
@@ -20,16 +20,14 @@ rule download_harmonised_overture:
     input:
         duckdb_extensions=rules.download_duckdb_extensions.output.path,
     output:
-        path="<resources>/automatic/overture/harmonise/{country}_{subtype}.parquet",
+        path="<resources>/automatic/overture/harmonise/{release}/{country}_{subtype}.parquet",
     log:
-        "<logs>/overture/download_and_harmonise/{country}_{subtype}.log",
+        "<logs>/overture/download_and_harmonise/{release}/{country}_{subtype}.log",
     localrule: True
     conda:
         "../envs/module.yaml"
-    params:
-        version=config.get("overture_release", internal["overture_release"]),
     message:
-        "Downloading harmonised '{wildcards.country}_{wildcards.subtype}' dataset from Overture Maps."
+        "Downloading|harmonising Overture {wildcards.release}: {wildcards.country}_{wildcards.subtype}."
     script:
         "../scripts/download_harmonised_overture.py"
 
@@ -38,13 +36,13 @@ rule harmonise_gadm:
     input:
         raw=rules.download_gadm.output.path,
     output:
-        standardised="<resources>/automatic/gadm/harmonise/{country}_{subtype}.parquet",
+        standardised="<resources>/automatic/gadm/harmonise/{release}/{country}_{subtype}.parquet",
     log:
-        "<logs>/gadm/harmonise/{country}_{subtype}.log",
+        "<logs>/gadm/harmonise/{release}/{country}_{subtype}.log",
     conda:
         "../envs/module.yaml"
     message:
-        "Harmonising '{wildcards.country}_{wildcards.subtype}' GADM dataset."
+        "Harmonising GADM {wildcards.release}: {wildcards.country}_{wildcards.subtype}."
     script:
         "../scripts/harmonise_gadm.py"
 
@@ -53,35 +51,34 @@ rule harmonise_nuts:
     input:
         raw=rules.download_nuts.output.path,
     output:
-        path="<resources>/automatic/nuts/harmonise/{country}_{subtype}_{year}_{resolution}.parquet",
+        path="<resources>/automatic/nuts/harmonise/{release}/{country}_{subtype}_{resolution}.parquet",
     log:
-        "<logs>/nuts/harmonise/{country}_{subtype}_{year}_{resolution}.log",
+        "<logs>/nuts/harmonise/{release}/{country}_{subtype}_{resolution}.log",
     conda:
         "../envs/module.yaml"
     message:
-        "Harmonising '{wildcards.country}' NUTS dataset for '{wildcards.subtype}_{wildcards.resolution}_{wildcards.year}'."
+        "Harmonising NUTS {wildcards.release}: {wildcards.subtype}_{wildcards.resolution}."
     script:
         "../scripts/harmonise_nuts.py"
 
 
 rule download_harmonised_eez:
     output:
-        path="<resources>/automatic/eez/single/{eez}.parquet",
+        path="<resources>/automatic/eez/single/{release}/{eez}.parquet",
         plot=report(
-            "<resources>/automatic/eez/single/{eez}.png",
+            "<resources>/automatic/eez/single/{release}/{eez}.png",
             caption="../report/download_harmonised_eez.rst",
             category="Module Geo-Boundaries",
             subcategory="EEZ area",
         ),
     log:
-        "<logs>/eez/download_harmonised/{eez}.log",
+        "<logs>/eez/harmonise/{release}/{eez}.log",
     localrule: True
     conda:
         "../envs/module.yaml"
     params:
         timeouts=internal["timeouts"],
-        version=config.get("marine_regions_release", internal["marine_regions_release"]),
     message:
-        "Download and harmonise EEZ dataset '{wildcards.eez}'."
+        "Downloading|harmonising MarineRegions {wildcards.release}: {wildcards.eez}."
     script:
         "../scripts/download_harmonised_eez.py"

--- a/workflow/scripts/_schemas.py
+++ b/workflow/scripts/_schemas.py
@@ -27,6 +27,8 @@ class ShapesSchema(pa.DataFrameModel):
     "Shape (multi)polygon."
     parent: Series[str] = pa.Field(isin=SUPPORTED_DATASETS)
     "Parent dataset."
+    parent_release: Series[str]
+    "Release number of the parent dataset."
     parent_subtype: Series[str]
     "Region disaggregation level in the parent dataset."
     parent_id: Series[str]

--- a/workflow/scripts/download_gadm.py
+++ b/workflow/scripts/download_gadm.py
@@ -1,6 +1,5 @@
 """Download data from the GADM database.
 
-Built for version 4.1 of the dataset.
 https://gadm.org/index.html
 """
 
@@ -16,20 +15,32 @@ if TYPE_CHECKING:
     snakemake: Any
 
 
-GADM_URL = (
-    "https://geodata.ucdavis.edu/gadm/gadm4.1/json/gadm41_{country}_{subtype}.json{zip}"
-)
-GADM_CRS = "EPSG:4326"
+URL = "https://geodata.ucdavis.edu/gadm/gadm{release}/json/gadm{nodot}_{country}_{subtype}.json{zip}"
+CRS = "EPSG:4326"
+SUPPORTED = ("4.1",)
 
 
 def download_country_gadm(
-    country: str, subtype: str, timeouts: DownloadTimeouts, geojson_max_obj_size_mb: int
+    release: str,
+    country: str,
+    subtype: str,
+    timeouts: DownloadTimeouts,
+    geojson_max_obj_size_mb: int,
 ) -> gpd.GeoDataFrame:
     """Attempts to download country GADM data in .json or zipped json."""
     last_error: Exception | None = None
 
+    if release not in SUPPORTED:
+        raise ValueError(f"GADM {release=} is not supported.")
+
     for zip_ext in (".zip", ""):
-        url = GADM_URL.format(country=country, subtype=subtype, zip=zip_ext)
+        url = URL.format(
+            release=release,
+            nodot=release.replace(".", ""),
+            country=country,
+            subtype=subtype,
+            zip=zip_ext,
+        )
         try:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 tmp_path = Path(tmp_dir) / f"download.json{zip_ext}"
@@ -38,7 +49,7 @@ def download_country_gadm(
                 gdf = read_geojson_file(tmp_path, geojson_max_obj_size_mb)
                 if gdf.empty:
                     raise RuntimeError(f"Downloaded empty GADM file from {url!r}.")
-                return gdf.to_crs(GADM_CRS)
+                return gdf.to_crs(CRS)
 
         except Exception as exc:
             last_error = exc
@@ -51,6 +62,7 @@ def main():
     """Main snakemake process."""
     timeouts = DownloadTimeouts(**snakemake.params.timeouts)
     country = download_country_gadm(
+        snakemake.wildcards.release,
         snakemake.wildcards.country,
         snakemake.wildcards.subtype,
         timeouts,
@@ -60,5 +72,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.stderr = open(snakemake.log[0], "w")
+    sys.stderr = open(snakemake.log[0], "w", buffering=1)
     main()

--- a/workflow/scripts/download_geoboundaries.py
+++ b/workflow/scripts/download_geoboundaries.py
@@ -1,9 +1,8 @@
-"""Download data from the geoBoundaries API.
+"""Download data from the geoBoundaries repository.
 
-https://www.geoboundaries.org/api.html
+https://github.com/wmgeolab/geoBoundaries
 """
 
-import json
 import sys
 import tempfile
 from pathlib import Path
@@ -16,36 +15,28 @@ if TYPE_CHECKING:
     snakemake: Any
 
 
-GEOBOUNDARIES_API_URL = (
-    "https://www.geoboundaries.org/api/current/{release_type}/{country}/ADM{subtype}/"
+URL = (
+    "https://github.com/wmgeolab/geoBoundaries/raw/refs/tags/v{release}/releaseData/"
+    "{release_type}/{country}/ADM{subtype}/geoBoundaries-{country}-ADM{subtype}.geojson"
 )
-GEOBOUNDARIES_CRS = "EPSG:4326"
+CRS = "EPSG:4326"
 
 
 def download_country_geoboundaries(
     country: str,
     subtype: str,
+    release: str,
     release_type: str,
     timeouts: DownloadTimeouts,
     geojson_max_obj_size_mb: int,
 ) -> gpd.GeoDataFrame:
-    """Download country data from geoBoundaries.
-
-    Uses the current geoBoundaries API endpoint.
-    The concrete dataset version returned in the metadata JSON response.
-    """
-    api_url = GEOBOUNDARIES_API_URL.format(
-        release_type=release_type, country=country, subtype=subtype
+    """Download country data from geoBoundaries."""
+    geojson_url = URL.format(
+        release=release, release_type=release_type, country=country, subtype=subtype
     )
 
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = Path(tmp_dir)
-
-        metadata_path = tmp_path / "metadata.json"
-        download_file(api_url, metadata_path, timeouts)
-
-        metadata = json.loads(metadata_path.read_text())
-        geojson_url = metadata["gjDownloadURL"]
 
         geojson_path = tmp_path / "download.geojson"
         download_file(geojson_url, geojson_path, timeouts)
@@ -56,16 +47,17 @@ def download_country_geoboundaries(
                 f"Downloaded empty geoBoundaries file from {geojson_url!r}."
             )
 
-    return gdf.to_crs(GEOBOUNDARIES_CRS)
+    return gdf.to_crs(CRS)
 
 
-def main():
+def main() -> None:
     """Main snakemake process."""
     timeouts = DownloadTimeouts(**snakemake.params.timeouts)
 
     country = download_country_geoboundaries(
         snakemake.wildcards.country,
         snakemake.wildcards.subtype,
+        snakemake.wildcards.release,
         snakemake.wildcards.release_type,
         timeouts,
         snakemake.params.geojson_max_obj_size_mb,
@@ -74,5 +66,5 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.stderr = open(snakemake.log[0], "w")
+    sys.stderr = open(snakemake.log[0], "w", buffering=1)
     main()

--- a/workflow/scripts/download_harmonised_eez.py
+++ b/workflow/scripts/download_harmonised_eez.py
@@ -126,7 +126,7 @@ def transform_to_schema(
     """
     if gdf is not None:
         if semver.VersionInfo.parse(release).major == 2:
-            standardised = _standardise_v2(gdf, country_id)
+            standardised = _standardise_v2(gdf, country_id, release)
         else:
             raise RuntimeError(
                 f"Unsupported version {release} for MarineRegions EEZ download."
@@ -139,7 +139,7 @@ def transform_to_schema(
     return standardised
 
 
-def _standardise_v2(gdf: gpd.GeoDataFrame, country_id: str) -> gpd.GeoDataFrame:
+def _standardise_v2(gdf: gpd.GeoDataFrame, country_id: str, release: str) -> gpd.GeoDataFrame:
     """Standardise a MarineRegions EEZ dataset downloaded with WFS version 2.x."""
     standardised = gpd.GeoDataFrame(
         {
@@ -150,6 +150,7 @@ def _standardise_v2(gdf: gpd.GeoDataFrame, country_id: str) -> gpd.GeoDataFrame:
             "shape_class": "maritime",
             "geometry": gdf["geometry"],
             "parent": "marineregions",
+            "parent_release": release,
             "parent_subtype": "eez",
             "parent_id": gdf["mrgid"],
             "parent_name": gdf["geoname"],

--- a/workflow/scripts/download_harmonised_eez.py
+++ b/workflow/scripts/download_harmonised_eez.py
@@ -109,7 +109,7 @@ def get_eez_by_cql(
 
 
 def transform_to_schema(
-    gdf: gpd.GeoDataFrame | None, country_id: str, version: str
+    gdf: gpd.GeoDataFrame | None, country_id: str, release: str
 ) -> gpd.GeoDataFrame:
     """Transform the MarineRegions dataset for better compatibility.
 
@@ -119,17 +119,17 @@ def transform_to_schema(
     Args:
         gdf (gpd.GeoDataFrame): A marine regions geo-dataframe.
         country_id (str): ISO3 country id from the workflow.
-        version (str): WFS version used to download the data.
+        release (str): WFS release used to download the data.
 
     Returns:
         gpd.GeoDataFrame: standardised dataframe.
     """
     if gdf is not None:
-        if semver.VersionInfo.parse(version).major == 2:
+        if semver.VersionInfo.parse(release).major == 2:
             standardised = _standardise_v2(gdf, country_id)
         else:
             raise RuntimeError(
-                f"Unsupported version {version} for MarineRegions EEZ download."
+                f"Unsupported version {release} for MarineRegions EEZ download."
             )
         # Remove cases without territorial ISO code
         standardised = standardised[~standardised["country_id"].isna()]
@@ -193,7 +193,7 @@ def download_eez(
     cql_filter: str,
     country_id: str,
     timeouts: _utils.DownloadTimeouts,
-    version: str,
+    release: str,
     *,
     allow_empty: bool,
 ) -> gpd.GeoDataFrame:
@@ -202,28 +202,28 @@ def download_eez(
     If no EEZ exists for a country query, the dataframe will be empty.
     MarineRegions ID queries are expected to return exactly one dataset.
     """
-    gdf = get_eez_by_cql(cql_filter, timeouts, version)
+    gdf = get_eez_by_cql(cql_filter, timeouts, release)
     if gdf is None and not allow_empty:
         raise RuntimeError(f"Configured EEZ query {cql_filter!r} returned no features")
 
-    return transform_to_schema(gdf, country_id, version)
+    return transform_to_schema(gdf, country_id, release)
 
 
 def main() -> None:
     """Main snakemake process."""
     timeouts = _utils.DownloadTimeouts(**snakemake.params.timeouts)
     eez = snakemake.wildcards.eez
-    version = snakemake.params.version
+    release = snakemake.wildcards.release
 
     if eez.isdigit():
         label = f"mrgid {eez}"
         gdf = download_eez(
-            f"mrgid={int(eez)}", "extra_eez", timeouts, version, allow_empty=False
+            f"mrgid={int(eez)}", "extra_eez", timeouts, release, allow_empty=False
         )
     elif len(eez) == 3 and eez.isalpha() and eez.isupper():
         label = eez
         gdf = download_eez(
-            f"iso_ter1='{eez}'", eez, timeouts, version, allow_empty=True
+            f"iso_ter1='{eez}'", eez, timeouts, release, allow_empty=True
         )
     else:
         raise ValueError(f"Unsupported EEZ identifier: {eez!r}")
@@ -235,5 +235,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    sys.stderr = open(snakemake.log[0], "w")
+    sys.stderr = open(snakemake.log[0], "w", buffering=1)
     main()

--- a/workflow/scripts/download_harmonised_eez.py
+++ b/workflow/scripts/download_harmonised_eez.py
@@ -139,7 +139,9 @@ def transform_to_schema(
     return standardised
 
 
-def _standardise_v2(gdf: gpd.GeoDataFrame, country_id: str, release: str) -> gpd.GeoDataFrame:
+def _standardise_v2(
+    gdf: gpd.GeoDataFrame, country_id: str, release: str
+) -> gpd.GeoDataFrame:
     """Standardise a MarineRegions EEZ dataset downloaded with WFS version 2.x."""
     standardised = gpd.GeoDataFrame(
         {

--- a/workflow/scripts/download_harmonised_overture.py
+++ b/workflow/scripts/download_harmonised_overture.py
@@ -87,14 +87,14 @@ def _resolve_overture_glob(version: str) -> str:
     return S3_GLOB.format(bucket=S3_BUCKET, version=version)
 
 
-def download_country_overture(country: str, subtype: str, version: str, path: str):
+def download_country_overture(country: str, subtype: str, release: str, path: str):
     """Download country division areas from Overture maps.
 
     Uses duckdb for remote interfacing and 'larger than memory' file generation.
     """
     # Prepare variables for the request
     country_a2 = CC.convert(country, src="ISO3", to="ISO2")
-    overture_glob = _resolve_overture_glob(version)
+    overture_glob = _resolve_overture_glob(release)
 
     # Setup SQL connection to the remote dataset
     connection = duckdb.connect()
@@ -136,13 +136,13 @@ def download_country_overture(country: str, subtype: str, version: str, path: st
 
 
 def validate_country_overture(
-    path: str, country: str, subtype: str, version: str
+    path: str, country: str, subtype: str, release: str
 ) -> None:
     """Run quick checks against our schema."""
     gdf = gpd.read_parquet(path)
     if gdf.empty:
         raise ValueError(
-            f"Invalid request for '{country}-{subtype}-{version}'. "
+            f"Invalid request for '{country}-{subtype}-{release}'. "
             "Please evaluate your request at https://overturemaps.org/."
         )
     ShapesSchema.validate(gdf)
@@ -153,13 +153,13 @@ def main() -> None:
     download_country_overture(
         country=snakemake.wildcards.country,
         subtype=snakemake.wildcards.subtype,
-        version=snakemake.params.version,
+        release=snakemake.wildcards.release,
         path=snakemake.output.path,
     )
     validate_country_overture(
         country=snakemake.wildcards.country,
         subtype=snakemake.wildcards.subtype,
-        version=snakemake.params.version,
+        release=snakemake.wildcards.release,
         path=snakemake.output.path,
     )
 

--- a/workflow/scripts/download_harmonised_overture.py
+++ b/workflow/scripts/download_harmonised_overture.py
@@ -59,14 +59,14 @@ def _check_release(s3, version: str) -> bool:
     return resp.get("KeyCount", 0) > 0
 
 
-def _resolve_overture_glob(version: str) -> str:
-    """Return a valid Overture glob for the divisions dataset.
+def _resolve_overture_glob(version: str) -> tuple[str, str]:
+    """Return a valid Overture glob and its concrete release.
 
     Args:
         version (str): version to resolve. Can be Calver ('yyyy.mm.dd.x') or 'latest'.
 
     Returns:
-        str: valid Overture S3 glob.
+        tuple[str, str]: valid Overture S3 glob and concrete release.
     """
     s3 = boto3.client(
         "s3", region_name=S3_REGION, config=Config(signature_version=UNSIGNED)
@@ -84,7 +84,7 @@ def _resolve_overture_glob(version: str) -> str:
                 f"Requested version {version} is not in release list {releases}."
             )
 
-    return S3_GLOB.format(bucket=S3_BUCKET, version=version)
+    return S3_GLOB.format(bucket=S3_BUCKET, version=version), version
 
 
 def download_country_overture(country: str, subtype: str, release: str, path: str):
@@ -94,7 +94,7 @@ def download_country_overture(country: str, subtype: str, release: str, path: st
     """
     # Prepare variables for the request
     country_a2 = CC.convert(country, src="ISO3", to="ISO2")
-    overture_glob = _resolve_overture_glob(release)
+    overture_glob, parent_release = _resolve_overture_glob(release)
 
     # Setup SQL connection to the remote dataset
     connection = duckdb.connect()
@@ -112,6 +112,7 @@ def download_country_overture(country: str, subtype: str, release: str, path: st
                 class AS shape_class,
                 geometry,
                 'overture' AS parent,
+                '{parent_release}' AS parent_release,
                 subtype AS parent_subtype,
                 id AS parent_id,
                 names.primary AS parent_name

--- a/workflow/scripts/download_nuts.py
+++ b/workflow/scripts/download_nuts.py
@@ -11,15 +11,15 @@ from _utils import DownloadTimeouts, download_file
 if TYPE_CHECKING:
     snakemake: Any
 
-URL = "https://gisco-services.ec.europa.eu/distribution/v2/nuts/gpkg/NUTS_RG_{resolution}_{year}_{crs}_LEVL_{level}.gpkg"
+URL = "https://gisco-services.ec.europa.eu/distribution/v2/nuts/gpkg/NUTS_RG_{resolution}_{release}_{crs}_LEVL_{level}.gpkg"
 NUTS_CRS = 3035
 
 
 def download_nuts_version(
-    year: int, resolution: str, level: str, timeouts: DownloadTimeouts
+    release: int, resolution: str, level: str, timeouts: DownloadTimeouts
 ) -> gpd.GeoDataFrame:
     """Download an aggregated NUTS datafile for the requested configuration."""
-    url = URL.format(year=year, resolution=resolution, crs=NUTS_CRS, level=level)
+    url = URL.format(release=release, resolution=resolution, crs=NUTS_CRS, level=level)
     with tempfile.TemporaryDirectory() as temp_dir:
         tmp_path = Path(temp_dir) / "download.gpkg"
         download_file(url, tmp_path, timeouts)
@@ -33,7 +33,7 @@ def download_nuts_version(
 def main():
     """Main snakemake process."""
     gdf = download_nuts_version(
-        year=snakemake.wildcards.year,
+        release=snakemake.wildcards.release,
         resolution=snakemake.wildcards.resolution,
         level=snakemake.wildcards.subtype,
         timeouts=DownloadTimeouts(**snakemake.params.timeouts),

--- a/workflow/scripts/harmonise_gadm.py
+++ b/workflow/scripts/harmonise_gadm.py
@@ -12,13 +12,14 @@ sys.stderr = open(snakemake.log[0], "w")
 
 
 def standardise_country_gadm(
-    input_path: str, country_id: str, subtype: str, output_path: str
+    input_path: str, country_id: str, release:str, subtype: str, output_path: str
 ):
     """Transformation of GADM dataset to clio.
 
     Args:
         input_path (str): path to input file.
         country_id (str): ISO alpha 3 code.
+        release (str): release number.
         subtype (str): regional definition in the parent dataset (0, 1, 2).
         output_path (str): path to output file.
     """
@@ -30,6 +31,7 @@ def standardise_country_gadm(
             "shape_class": "land",
             "geometry": gdf["geometry"],
             "parent": "gadm",
+            "parent_release": release,
             "parent_subtype": str(subtype),
             "parent_id": gdf[f"GID_{subtype}"],
             "parent_name": gdf[f"NAME_{subtype}"]
@@ -47,6 +49,7 @@ if __name__ == "__main__":
     standardise_country_gadm(
         input_path=snakemake.input.raw,
         country_id=snakemake.wildcards.country,
+        release=snakemake.wildcards.release,
         subtype=snakemake.wildcards.subtype,
         output_path=snakemake.output.standardised,
     )

--- a/workflow/scripts/harmonise_gadm.py
+++ b/workflow/scripts/harmonise_gadm.py
@@ -12,7 +12,7 @@ sys.stderr = open(snakemake.log[0], "w")
 
 
 def standardise_country_gadm(
-    input_path: str, country_id: str, release:str, subtype: str, output_path: str
+    input_path: str, country_id: str, release: str, subtype: str, output_path: str
 ):
     """Transformation of GADM dataset to clio.
 

--- a/workflow/scripts/harmonise_geoboundaries.py
+++ b/workflow/scripts/harmonise_geoboundaries.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def harmonise_geoboundaries(
-    input_path: str, country_id: str, release_type: str
+    input_path: str, country_id: str, release:str, release_type: str
 ) -> gpd.GeoDataFrame:
     """Harmonise a geoBoundaries dataset including metadata."""
     gdf = gpd.read_parquet(input_path)
@@ -29,6 +29,7 @@ def harmonise_geoboundaries(
             "shape_class": "land",
             "geometry": gdf["geometry"],
             "parent": "geoboundaries",
+            "parent_release": release,
             "parent_subtype": f"{release_type}_" + shape_type,
             "parent_id": shape_id,
             "parent_name": gdf["shapeName"],
@@ -45,6 +46,7 @@ def main():
     gdf = harmonise_geoboundaries(
         input_path=snakemake.input.raw,
         country_id=snakemake.wildcards.country,
+        release=snakemake.wildcards.release,
         release_type=snakemake.wildcards.release_type,
     )
     gdf.to_parquet(snakemake.output.path)

--- a/workflow/scripts/harmonise_geoboundaries.py
+++ b/workflow/scripts/harmonise_geoboundaries.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 
 def harmonise_geoboundaries(
-    input_path: str, country_id: str, release:str, release_type: str
+    input_path: str, country_id: str, release: str, release_type: str
 ) -> gpd.GeoDataFrame:
     """Harmonise a geoBoundaries dataset including metadata."""
     gdf = gpd.read_parquet(input_path)

--- a/workflow/scripts/harmonise_nuts.py
+++ b/workflow/scripts/harmonise_nuts.py
@@ -51,6 +51,7 @@ def standardise_country_nuts(
             "shape_class": "land",
             "geometry": nuts_gdf["geometry"],
             "parent": "nuts",
+            "parent_release": release,
             "parent_subtype": nuts_gdf["LEVL_CODE"].astype(str),
             "parent_id": nuts_gdf["NUTS_ID"],
             "parent_name": nuts_gdf["NUTS_NAME"],

--- a/workflow/scripts/harmonise_nuts.py
+++ b/workflow/scripts/harmonise_nuts.py
@@ -27,18 +27,17 @@ def _iso_a3_to_nuts(code):
 
 
 def standardise_country_nuts(
-    raw_file: str, country_id: str, year: int, subtype: str, output_path: str
+    raw_file: str, country_id: str, release: int, output_path: str
 ):
     """Extract country data from a NUTS file and standardise it.
 
     Args:
         raw_file (str): NUTS parquet file with raw data.
         country_id (str): ISO alpha 3 country code.
-        year (int): NUTS year version.
-        subtype (str): Disaggregation level of the file (i.e., 0, 1, 2...).
+        release (int): NUTS release year.
         output_path (str): output path for the standardised file.
     """
-    nuts_version = f"nuts{year}"
+    nuts_release = f"nuts{release}"
     nuts_id = _iso_a3_to_nuts(country_id)
 
     nuts_gdf = gpd.read_parquet(raw_file)
@@ -46,7 +45,7 @@ def standardise_country_nuts(
     standardised_gdf = gpd.GeoDataFrame(
         {
             "shape_id": nuts_gdf["NUTS_ID"].apply(
-                lambda x: country_id + "_" + nuts_version + "_" + x
+                lambda x: country_id + "_" + nuts_release + "_" + x
             ),
             "country_id": country_id,
             "shape_class": "land",
@@ -65,7 +64,6 @@ if __name__ == "__main__":
     standardise_country_nuts(
         raw_file=snakemake.input.raw,
         country_id=snakemake.wildcards.country,
-        year=snakemake.wildcards.year,
-        subtype=snakemake.wildcards.subtype,
+        release=snakemake.wildcards.release,
         output_path=snakemake.output.path,
     )


### PR DESCRIPTION
Fixes #84, #80

## Summary of changes in this pull request

* Improves version handling for all datasets. These are based on internal defaults.
* Ups geoBoundaries version to 6.0.0.

## Reviewer checklist

* [ ] There are no `pip` dependencies in the module's environment files (`workflow/envs/`).
* [ ] All rules use `pathvars` (e.g., `<results>`) in their inputs and outputs.
* [ ] The integration test-suite is successful, including:
    * [ ] `pre-commit.ci` tests pass.
    * [ ] tests pass for all relevant OS configurations (linux, osx, windows).
* [ ] Module documentation is up-to-date, including:
    * [ ] `INTERFACE.yaml` mentions all relevant `pathvars` and `wildcards`.
    * [ ] `README.md` describes how to use the module and has the necessary citations.
